### PR TITLE
Remove Alpha status for Sodium 1.18

### DIFF
--- a/alternatives/sodium.mjs
+++ b/alternatives/sodium.mjs
@@ -6,7 +6,7 @@ export default new Mod(
 	"Modern rendering engine and client-side optimization mod for Minecraft.",
 )
 .icon("https://cdn.modrinth.com/data/AANobbMI/icon.png")
-.add_version(16, 17, {id: 18, note: "Alpha"})
+.add_version(16, 17, 18)
 .add_category("Performance", "Client")
 .add_link(
 	{ host: "modrinth" },


### PR DESCRIPTION
See https://modrinth.com/mod/sodium/version/mc1.18.2-0.4.1:

> ... we're dropping the alpha version and making this a proper release.