### PR TITLE
Update Dynamic FPS supported versions and metadata

### DIFF
--- a/alternatives/dynamic-fps.mjs
+++ b/alternatives/dynamic-fps.mjs
@@ -2,11 +2,12 @@ import Mod from "../build_src/mod.mjs";
 
 const mod = new Mod(
 	"Dynamic FPS",
-	"juliand665",
-	"Improve performance when Minecraft is in the background.",
+	"juliand665, LostLuma",
+	"Reduce resource usage while Minecraft is in the background or idle.",
 )
 .icon("https://cdn.modrinth.com/data/LQ3K71Q1/icon.png")
-.add_version({ loader: ["quilt"], v: [18, 19, 20] }, { loader: ["fabric"], v: [14, 15, 16, 17, 18, 19, 20] }, { loader: ["forge"], v: [16.5, 17, 18, 19, 20] }, { loader: ["neoforge"], v: [20] })
+// Some early 1.14.x and 1.16.x Fabric / Quilt versions are only available on GitHub and CurseForge, so the import doesn't catch them
+.add_version({ loader: ["fabric", "quilt"], v: [14, 14.1, 14.2, 15, 16, 16.1, 17, 18, 19, 20] }, { loader: ["forge"], v: [16.5, 17, 18, 19, 20] }, { loader: ["neoforge"], v: [20.2, 20.3, 20.4] })
 .add_category("Performance", "Client")
 .add_link(
 	{ host: "modrinth" },


### PR DESCRIPTION
Hello, I noticed that the supported version range for Dynamic FPS on Fabric is incomplete as some versions for the earlier 1.14.x and 1.16.x releases never made it to Modrinth (and I am not looking to provide backports for them), so I figured it would be reasonable to add them manually as they are available on GitHub and CurseForge. If this is not the case feel free to close this PR.

While I was at it I also fixed supported NeoForge versions, updated the description since it was changed a little while ago, and added myself to the author list as I maintain the mod.

![before](https://github.com/LambdAurora/optifine_alternatives/assets/38926001/0ff76a44-bbd6-4eab-8e0a-8728f7796ff0)

![after](https://github.com/LambdAurora/optifine_alternatives/assets/38926001/197d7c6f-94b5-4c06-9eaf-e7644a221f16)

... I'm not sure why Fabric and Quilt switched places but I don't think that really matters.