### PR TITLE
Rename FabricSkyboxes to Nuit

### DIFF
--- a/alternatives/nuit.mjs
+++ b/alternatives/nuit.mjs
@@ -1,11 +1,11 @@
 import Mod from "../build_src/mod.ts";
 
 const mod = new Mod(
-	"FabricSkyboxes",
-	"AMereBagatelle",
-	"Allows resource packs to define custom skyboxes. OptiFine format is not compatible by default, converters are available.",
+	"Nuit",
+	"FlashyReese",
+	"Allows resource packs to define custom skyboxes. OptiFine format is not compatible by default, converters are available. Formerly known as FabricSkyboxes.",
 )
-.icon("https://cdn.modrinth.com/data/YBz7DOs8/icon.png")
+.icon("https://cdn.modrinth.com/data/YBz7DOs8/be8486a3e6a10476f6989928e766e154a6b271bc_96.webp")
 .add_version({ loader: ["fabric", "quilt"], v: [17, 18, 19.4, 20.4] })
 .add_category("Cosmetic")
 .add_link(


### PR DESCRIPTION
FabricSkyboxes was renamed to Nuit (see the [modrinth listing](https://modrinth.com/mod/nuit)), changed developers, and also broke its old icon.